### PR TITLE
Change Reset Button Function to toggle sysreset | Fixed power control crash issue

### DIFF
--- a/power-control-x86/config/power-config-host0.json
+++ b/power-control-x86/config/power-config-host0.json
@@ -4,5 +4,6 @@
   "PwrOutOn": "POWER_OUT_ON",
   "PwrOutOff": "POWER_OUT_OFF",
   "RstButton": "RESET_BUTTON",
+  "RstOutBtn": "RESET_OUT_BUTTON",
   "RstOut": "RESET_OUT"
 }


### PR DESCRIPTION
1. Reset button changed from toggling the virtual_reseat gpio to the sysreset gpio pin.
2. Commented out the code trying to set property for osIface which did not exist causing power control to crash.

